### PR TITLE
Fix incorrect website link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Our iOS app is free for downloading available on the AppStore
 
 <a href="https://apps.apple.com/app/id6743121005?itsct=apps_box_badge&amp;itscg=30200" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1561593600" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
 
-####  🌎 https://OpenCloud.com
+####  🌎 https://opencloud.eu
 
 | Account List                                                 | File List                                                    | File Actions                                                 | Preview Files                                                | Quick Access                                                 | Settings                                                     |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |


### PR DESCRIPTION
## Fix incorrect website link in README.md

This PR fixes the incorrect website link in the README.md. The current link points to opencloud.com (which is unrelated to this project) instead of opencloud.eu.

### Changes
- Change website link from `https://OpenCloud.com` to `https://opencloud.eu`

This issue was reported in the community Matrix chat by Max.

cc @guruz