### PR TITLE
Fix: Hide quota display for unlimited storage (issue #11)

### DIFF
--- a/OpenCloudAppShared/Client/View Controllers/ClientItemViewController.swift
+++ b/OpenCloudAppShared/Client/View Controllers/ClientItemViewController.swift
@@ -1245,14 +1245,17 @@ open class ClientItemViewController: CollectionViewController, SortBarDelegate, 
 		}
 
 		if let driveQuota = driveQuota, let remainingBytes = driveQuota.remaining {
-			quotaInfoText = OCLocalizedFormat("{{remaining}} available", [
-				"remaining" : ByteCountFormatter.string(fromByteCount: remainingBytes.int64Value, countStyle: .file)
-			])
+			// Only show available space if quota is not unlimited (total != 0)
+			if let totalBytes = driveQuota.total, totalBytes.int64Value != 0 {
+				quotaInfoText = OCLocalizedFormat("{{remaining}} available", [
+					"remaining" : ByteCountFormatter.string(fromByteCount: remainingBytes.int64Value, countStyle: .file)
+				])
 
-			if folderStatisticsText.count > 0 {
-				folderStatisticsText += "\n" + quotaInfoText
-			} else {
-				folderStatisticsText = quotaInfoText
+				if folderStatisticsText.count > 0 {
+					folderStatisticsText += "\n" + quotaInfoText
+				} else {
+					folderStatisticsText = quotaInfoText
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
This PR fixes the quota display issue where "9.22 EB available" is shown for accounts with unlimited storage quota. The iOS app now hides the "available" space display when the quota is unlimited (total = 0), matching the web interface behavior.

**⚠️ Note: This is a proposed fix that has not been built or tested yet.**

## Related Issue
Fixes #11

## Motivation and Context
When users have "No restriction" set for their quota, the backend returns `remaining: INT64_MAX` (≈ 9.22 EB). The iOS app was displaying this literally as "9.22 EB available", which is confusing for users. The web interface correctly hides the available space in this case.

## How Has This Been Tested?
**Not tested yet** - This is a code review proposal. Testing needed:
- [ ] Build the app
- [ ] Test with unlimited quota account - should not show "available"
- [ ] Test with limited quota account - should still show "X GB available"

## Screenshots (if appropriate):
Not available - not built/tested yet

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**docs repository**](https://github.com/opencloud-eu/docs/issues).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have set a pull request label and a meaningful title for changelog automation