### PR TITLE
Add custom OIDC scope

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "ios-sdk"]
 	path = ios-sdk
-	#url = https://github.com/opencloud-eu/ios-sdk.git
-	url = ../ios-sdk.git
+	url = https://github.com/gpongelli/opencloud-ios-sdk.git
+	#url = ../ios-sdk.git
+	branch = custom-claim

--- a/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
+++ b/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
@@ -151,8 +151,8 @@ class BookmarkComposer: NSObject {
 		// Probe URL
 		bookmark.url = serverURL
 
-		let customScope = (OCAppIdentity.shared.userDefaults! as UserDefaults).object(forKey:"oidc-custom-claim")
-		bookmark.customOIDCClaim = customScope as? String
+		let customScopes = (OCAppIdentity.shared.userDefaults! as UserDefaults).object(forKey:"oidc-custom-scopes")
+		bookmark.customOIDCScopes = customScopes as? String
 
 		let connection = instantiateConnection(for: bookmark)
 

--- a/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
+++ b/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
@@ -77,6 +77,9 @@ class BookmarkComposer: NSObject {
 	}
 
 	func instantiateConnection(for bmark: OCBookmark) -> OCConnection {
+		let customScopes = (OCAppIdentity.shared.userDefaults! as UserDefaults).object(forKey:"oidc-custom-scopes")
+		bmark.customOIDCScopes = customScopes as? String
+
 		let connection = OCConnection(bookmark: bmark)
 
 		connection.hostSimulator = OCHostSimulatorManager.shared.hostSimulator(forLocation: .accountSetup, for: self)
@@ -150,9 +153,6 @@ class BookmarkComposer: NSObject {
 
 		// Probe URL
 		bookmark.url = serverURL
-
-		let customScopes = (OCAppIdentity.shared.userDefaults! as UserDefaults).object(forKey:"oidc-custom-scopes")
-		bookmark.customOIDCScopes = customScopes as? String
 
 		let connection = instantiateConnection(for: bookmark)
 

--- a/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
+++ b/OpenCloud/Bookmarks/Composer/BookmarkComposer.swift
@@ -151,6 +151,9 @@ class BookmarkComposer: NSObject {
 		// Probe URL
 		bookmark.url = serverURL
 
+		let customScope = (OCAppIdentity.shared.userDefaults! as UserDefaults).object(forKey:"oidc-custom-claim")
+		bookmark.customOIDCClaim = customScope as? String
+
 		let connection = instantiateConnection(for: bookmark)
 
 		hudMessage = OCLocalizedString("Contacting server…", nil)

--- a/OpenCloud/Resources/Localizable.xcstrings
+++ b/OpenCloud/Resources/Localizable.xcstrings
@@ -511,6 +511,9 @@
     "Credentials" : {
 
     },
+    "Custom OIDC scopes to be appended to fixed ones." : {
+
+    },
     "Cut" : {
 
     },
@@ -1239,6 +1242,12 @@
 
     },
     "Offline files use" : {
+
+    },
+    "OIDC Scopes" : {
+
+    },
+    "OIDC settings" : {
 
     },
     "OK" : {

--- a/OpenCloud/Settings/DisplaySettingsSection.swift
+++ b/OpenCloud/Settings/DisplaySettingsSection.swift
@@ -51,12 +51,6 @@ class DisplaySettingsSection: SettingsSection {
 			}
 		}, title: OCLocalizedString("Enable diagnostics", nil), value: DiagnosticManager.shared.enabled, identifier: "diagnostics-enabled"))
 
-		self.add(row: StaticTableViewRow(textFieldWithAction: { (row, _, _) in
-			if let oidcScopes = row.value as? String {
-				DisplaySettings.shared.oidcCustomScopes = oidcScopes as NSString
-			}
-		}, placeholder: "Custom OIDC scopes", value: DisplaySettings.shared.oidcCustomScopes as String, autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
-
 		if OCLicenseQAProvider.isQAUnlockPossible {
 			self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
 				if let qaUnlockedProFeatures = row.value as? Bool {

--- a/OpenCloud/Settings/DisplaySettingsSection.swift
+++ b/OpenCloud/Settings/DisplaySettingsSection.swift
@@ -55,7 +55,7 @@ class DisplaySettingsSection: SettingsSection {
 			if let oidcClaim = row.value as? String {
 				DisplaySettings.shared.oidcCustomClaim = oidcClaim as NSString
 			}
-		}, placeholder: "Custom OIDC claim", value: "", autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
+		}, placeholder: "Custom OIDC claim", value: DisplaySettings.shared.oidcCustomClaim as String, autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
 
 		if OCLicenseQAProvider.isQAUnlockPossible {
 			self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in

--- a/OpenCloud/Settings/DisplaySettingsSection.swift
+++ b/OpenCloud/Settings/DisplaySettingsSection.swift
@@ -51,6 +51,12 @@ class DisplaySettingsSection: SettingsSection {
 			}
 		}, title: OCLocalizedString("Enable diagnostics", nil), value: DiagnosticManager.shared.enabled, identifier: "diagnostics-enabled"))
 
+		self.add(row: StaticTableViewRow(textFieldWithAction: { (row, _, _) in
+			if let oidcClaim = row.value as? String {
+				DisplaySettings.shared.oidcCustomClaim = oidcClaim as NSString
+			}
+		}, value: "", autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
+
 		if OCLicenseQAProvider.isQAUnlockPossible {
 			self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in
 				if let qaUnlockedProFeatures = row.value as? Bool {

--- a/OpenCloud/Settings/DisplaySettingsSection.swift
+++ b/OpenCloud/Settings/DisplaySettingsSection.swift
@@ -55,7 +55,7 @@ class DisplaySettingsSection: SettingsSection {
 			if let oidcClaim = row.value as? String {
 				DisplaySettings.shared.oidcCustomClaim = oidcClaim as NSString
 			}
-		}, value: "", autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
+		}, placeholder: "Custom OIDC claim", value: "", autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
 
 		if OCLicenseQAProvider.isQAUnlockPossible {
 			self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in

--- a/OpenCloud/Settings/DisplaySettingsSection.swift
+++ b/OpenCloud/Settings/DisplaySettingsSection.swift
@@ -52,10 +52,10 @@ class DisplaySettingsSection: SettingsSection {
 		}, title: OCLocalizedString("Enable diagnostics", nil), value: DiagnosticManager.shared.enabled, identifier: "diagnostics-enabled"))
 
 		self.add(row: StaticTableViewRow(textFieldWithAction: { (row, _, _) in
-			if let oidcClaim = row.value as? String {
-				DisplaySettings.shared.oidcCustomClaim = oidcClaim as NSString
+			if let oidcScopes = row.value as? String {
+				DisplaySettings.shared.oidcCustomScopes = oidcScopes as NSString
 			}
-		}, placeholder: "Custom OIDC claim", value: DisplaySettings.shared.oidcCustomClaim as String, autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
+		}, placeholder: "Custom OIDC scopes", value: DisplaySettings.shared.oidcCustomScopes as String, autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
 
 		if OCLicenseQAProvider.isQAUnlockPossible {
 			self.add(row: StaticTableViewRow(switchWithAction: { (row, _) in

--- a/OpenCloud/Settings/OIDCSettingsSection.swift
+++ b/OpenCloud/Settings/OIDCSettingsSection.swift
@@ -1,0 +1,39 @@
+//
+//  OIDCSettingsSection.swift
+//  OpenCloud
+//
+//  Created by Gabriele Pongelli on 26.12.2025.
+//
+//
+
+/*
+ * Copyright (C) 2025, Gabriele Pongelli.
+ *
+ * This code is covered by the GNU Public License Version 3.
+ *
+ * For distribution utilizing Apple mechanisms please see https://opencloud.eu/contribute/iOS-license-exception/
+ * You should have received a copy of this license along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ *
+ */
+
+import UIKit
+import OpenCloudSDK
+import OpenCloudApp
+import OpenCloudAppShared
+
+class OIDCSettingsSection: SettingsSection {
+	override init(userDefaults: UserDefaults) {
+		super.init(userDefaults: userDefaults)
+
+		self.headerTitle = OCLocalizedString("OIDC settings", nil)
+
+		self.add(row: StaticTableViewRow(rowWithAction: { (_, _) in
+		}, title: OCLocalizedString("OIDC Scopes", nil), subtitle: OCLocalizedString("Custom OIDC scopes to be appended to fixed ones.", nil)))
+
+		self.add(row: StaticTableViewRow(textFieldWithAction: { (row, _, _) in
+			if let oidcScopes = row.value as? String {
+				DisplaySettings.shared.oidcCustomScopes = oidcScopes as NSString
+			}
+		}, placeholder: "Custom OIDC scopes", value: DisplaySettings.shared.oidcCustomScopes as String, autocorrectionType: UITextAutocorrectionType.no, identifier: "oidc-string"))
+	}
+}

--- a/OpenCloud/Settings/SettingsViewController.swift
+++ b/OpenCloud/Settings/SettingsViewController.swift
@@ -47,6 +47,7 @@ class SettingsViewController: StaticTableViewController {
 			self.addSection(UserInterfaceSettingsSection(userDefaults: userDefaults))
 			self.addSection(DataSettingsSection(userDefaults: userDefaults))
 			self.addSection(DisplaySettingsSection(userDefaults: userDefaults))
+			self.addSection(OIDCSettingsSection(userDefaults: userDefaults))
 			self.addSection(MediaFilesSettingsSection(userDefaults: userDefaults))
 
 			#if !DISABLE_APPSTORE_LICENSING

--- a/OpenCloudAppFramework/Display Settings/DisplaySettings.h
+++ b/OpenCloudAppFramework/Display Settings/DisplaySettings.h
@@ -35,8 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Drag files
 @property(assign,nonatomic) BOOL preventDraggingFiles;
 
-#pragma mark - OIDC Claim
-@property(assign,nonatomic) NSString *oidcCustomClaim;
+#pragma mark - OIDC Scopes
+@property(assign,nonatomic) NSString *oidcCustomScopes;
 
 #pragma mark - Query condition
 @property(nonatomic,readonly,nullable) OCQueryCondition *queryConditionForDisplaySettings;
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *DisplaySettingsShowHiddenFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .showHiddenFiles
 extern NSString *DisplaySettingsSortFoldersFirstPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .sortFoldersFirst
 extern NSString *DisplaySettingsPreventDraggingFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .preventDraggingFiles
-extern NSString *DisplaySettingsOidcCustomClaimPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .oidcCustomClaim
+extern NSString *DisplaySettingsOIDCCustomScopesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .oidcCustomScopes
 
 extern OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged; 	//!< Posted when display settings changed (internal use only)
 extern NSNotificationName DisplaySettingsChanged;				//!< Posted when display settings changed (for use by app + File Provider)
@@ -58,6 +58,6 @@ extern OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay; 		//!< The cl
 extern OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles;		//!< The class settings key for Show Hidden Files
 extern OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst;		//!< The class settings key for sorting folders first
 extern OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles;	//!< The class settings key if Drag Files is enabled
-extern OCClassSettingsKey OCClassSettingsKeyCustomOidcClaim;	//!< The class settings key for custom OIDC claim
+extern OCClassSettingsKey OCClassSettingsKeyCustomOidcScopes;	//!< The class settings key for custom OIDC scopes
 
 NS_ASSUME_NONNULL_END

--- a/OpenCloudAppFramework/Display Settings/DisplaySettings.h
+++ b/OpenCloudAppFramework/Display Settings/DisplaySettings.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Drag files
 @property(assign,nonatomic) BOOL preventDraggingFiles;
 
+#pragma mark - OIDC Claim
+@property(assign,nonatomic) NSString *oidcCustomClaim;
+
 #pragma mark - Query condition
 @property(nonatomic,readonly,nullable) OCQueryCondition *queryConditionForDisplaySettings;
 
@@ -46,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *DisplaySettingsShowHiddenFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .showHiddenFiles
 extern NSString *DisplaySettingsSortFoldersFirstPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .sortFoldersFirst
 extern NSString *DisplaySettingsPreventDraggingFilesPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .preventDraggingFiles
+extern NSString *DisplaySettingsOidcCustomClaimPrefsKey;			//!< The UserDefaults Key containing the BOOL value for .oidcCustomClaim
 
 extern OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged; 	//!< Posted when display settings changed (internal use only)
 extern NSNotificationName DisplaySettingsChanged;				//!< Posted when display settings changed (for use by app + File Provider)
@@ -54,5 +58,6 @@ extern OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay; 		//!< The cl
 extern OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles;		//!< The class settings key for Show Hidden Files
 extern OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst;		//!< The class settings key for sorting folders first
 extern OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles;	//!< The class settings key if Drag Files is enabled
+extern OCClassSettingsKey OCClassSettingsKeyCustomOidcClaim;	//!< The class settings key for custom OIDC claim
 
 NS_ASSUME_NONNULL_END

--- a/OpenCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/OpenCloudAppFramework/Display Settings/DisplaySettings.m
@@ -89,7 +89,7 @@
 		_showHiddenFiles = [self _showHiddenFilesValue];
 		_sortFoldersFirst = [self _sortFoldersFirst];
 		_preventDraggingFiles = [self _preventDraggingFilesValue];
-		_oidcCustomClaim = [self _oidcCustomClaimValue];
+		_oidcCustomScopes = [self _oidcCustomScopesValue];
 	}
 
 	return (self);
@@ -115,9 +115,9 @@
 	_preventDraggingFiles = [self _preventDraggingFilesValue];
 	[self didChangeValueForKey:@"preventDraggingFiles"];
 
-	[self willChangeValueForKey:@"oidcCustomClaim"];
-	_oidcCustomClaim = [self _oidcCustomClaimValue];
-	[self didChangeValueForKey:@"oidcCustomClaim"];
+	[self willChangeValueForKey:@"oidcCustomScopes"];
+	_oidcCustomScopes = [self _oidcCustomScopesValue];
+	[self didChangeValueForKey:@"oidcCustomScopes"];
 	
 	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
 }
@@ -195,24 +195,24 @@
 }
 
 
-#pragma mark - OIDC Custom Claim
-- (NSString*)_oidcCustomClaimValue
+#pragma mark - OIDC Custom Scopes
+- (NSString*)_oidcCustomScopesValue
 {
-	NSString *oidcClaim;
+	NSString *oidcScopes;
 
-	if ((oidcClaim = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsOidcCustomClaimPrefsKey]) != nil)
+	if ((oidcScopes = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsOIDCCustomScopesPrefsKey]) != nil)
 	{
-		return oidcClaim;
+		return oidcScopes;
 	}
 
-	return ([self classSettingForOCClassSettingsKey:OCClassSettingsKeyCustomOidcClaim]);
+	return ([self classSettingForOCClassSettingsKey:OCClassSettingsKeyCustomOidcScopes]);
 }
 
-- (void)setOidcCustomClaim:(NSString*)oidcCustomClaim
+- (void)setOidcCustomScopes:(NSString*)oidcCustomScopes
 {
-	_oidcCustomClaim = oidcCustomClaim;
+	_oidcCustomScopes = oidcCustomScopes;
 
-	[OCAppIdentity.sharedAppIdentity.userDefaults setValue:oidcCustomClaim forKey:DisplaySettingsOidcCustomClaimPrefsKey];
+	[OCAppIdentity.sharedAppIdentity.userDefaults setValue:oidcCustomScopes forKey:DisplaySettingsOIDCCustomScopesPrefsKey];
 
 	[self postChangeNotifications];
 }
@@ -271,7 +271,7 @@
 NSString *DisplaySettingsShowHiddenFilesPrefsKey = @"display-show-hidden-files";
 NSString *DisplaySettingsSortFoldersFirstPrefsKey = @"display-sort-folders-first";
 NSString *DisplaySettingsPreventDraggingFilesPrefsKey = @"display-prevent-dragging-files";
-NSString *DisplaySettingsOidcCustomClaimPrefsKey = @"oidc-custom-claim";
+NSString *DisplaySettingsOIDCCustomScopesPrefsKey = @"oidc-custom-scopes";
 
 OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged = @"org.opencloud.display-settings-changed";
 
@@ -281,4 +281,4 @@ OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay = @"display";
 OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles = @"show-hidden-files";
 OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst = @"sort-folders-first";
 OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles = @"prevent-dragging-files";
-OCClassSettingsKey OCClassSettingsKeyCustomOidcClaim = @"custom-claim";
+OCClassSettingsKey OCClassSettingsKeyCustomOidcScopes = @"custom-scopes";

--- a/OpenCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/OpenCloudAppFramework/Display Settings/DisplaySettings.m
@@ -89,6 +89,7 @@
 		_showHiddenFiles = [self _showHiddenFilesValue];
 		_sortFoldersFirst = [self _sortFoldersFirst];
 		_preventDraggingFiles = [self _preventDraggingFilesValue];
+		_oidcCustomClaim = [self _oidcCustomClaimValue];
 	}
 
 	return (self);
@@ -189,6 +190,29 @@
 	[self postChangeNotifications];
 }
 
+
+#pragma mark - OIDC Custom Claim
+- (NSString*)_oidcCustomClaimValue
+{
+	NSString *oidcClaim;
+
+	if ((oidcClaim = [OCAppIdentity.sharedAppIdentity.userDefaults objectForKey:DisplaySettingsOidcCustomClaimPrefsKey]) != nil)
+	{
+		return oidcClaim;
+	}
+
+	return ([self classSettingForOCClassSettingsKey:OCClassSettingsKeyCustomOidcClaim]);
+}
+
+- (void)setoidcCustomClaim:(NSString*)oidcCustomClaim
+{
+	_oidcCustomClaim = oidcCustomClaim;
+
+	[OCAppIdentity.sharedAppIdentity.userDefaults setValue:oidcCustomClaim forKey:DisplaySettingsPreventDraggingFilesPrefsKey];
+
+	[self postChangeNotifications];
+}
+
 #pragma mark - Query updating
 - (void)updateQueryWithDisplaySettings:(OCQuery *)query
 {
@@ -243,6 +267,7 @@
 NSString *DisplaySettingsShowHiddenFilesPrefsKey = @"display-show-hidden-files";
 NSString *DisplaySettingsSortFoldersFirstPrefsKey = @"display-sort-folders-first";
 NSString *DisplaySettingsPreventDraggingFilesPrefsKey = @"display-prevent-dragging-files";
+NSString *DisplaySettingsOidcCustomClaimPrefsKey = @"oidc-custom-claim";
 
 OCIPCNotificationName OCIPCNotificationNameDisplaySettingsChanged = @"org.opencloud.display-settings-changed";
 
@@ -252,3 +277,4 @@ OCClassSettingsIdentifier OCClassSettingsIdentifierDisplay = @"display";
 OCClassSettingsKey OCClassSettingsKeyDisplayShowHiddenFiles = @"show-hidden-files";
 OCClassSettingsKey OCClassSettingsKeyDisplaySortFoldersFirst = @"sort-folders-first";
 OCClassSettingsKey OCClassSettingsKeyDisplayPreventDraggingFiles = @"prevent-dragging-files";
+OCClassSettingsKey OCClassSettingsKeyCustomOidcClaim = @"custom-claim";

--- a/OpenCloudAppFramework/Display Settings/DisplaySettings.m
+++ b/OpenCloudAppFramework/Display Settings/DisplaySettings.m
@@ -115,6 +115,10 @@
 	_preventDraggingFiles = [self _preventDraggingFilesValue];
 	[self didChangeValueForKey:@"preventDraggingFiles"];
 
+	[self willChangeValueForKey:@"oidcCustomClaim"];
+	_oidcCustomClaim = [self _oidcCustomClaimValue];
+	[self didChangeValueForKey:@"oidcCustomClaim"];
+	
 	[[NSNotificationCenter defaultCenter] postNotificationName:DisplaySettingsChanged object:self];
 }
 
@@ -204,11 +208,11 @@
 	return ([self classSettingForOCClassSettingsKey:OCClassSettingsKeyCustomOidcClaim]);
 }
 
-- (void)setoidcCustomClaim:(NSString*)oidcCustomClaim
+- (void)setOidcCustomClaim:(NSString*)oidcCustomClaim
 {
 	_oidcCustomClaim = oidcCustomClaim;
 
-	[OCAppIdentity.sharedAppIdentity.userDefaults setValue:oidcCustomClaim forKey:DisplaySettingsPreventDraggingFilesPrefsKey];
+	[OCAppIdentity.sharedAppIdentity.userDefaults setValue:oidcCustomClaim forKey:DisplaySettingsOidcCustomClaimPrefsKey];
 
 	[self postChangeNotifications];
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to OpenCloud!

To make it possible for us to get your change reviewed and merged, please carefully fill out the information below.

Please note that any kind of change first has to be submitted to the main branch which holds the next major version of OpenCloud.
-->

## Description
<!--- Describe your changes in detail -->
This PR add the iOS side to manage OIDC custom scopes, as it can be already done with `WEB_OIDC_SCOPE` .
its companion PR on sdk side is https://github.com/opencloud-eu/ios-sdk/pull/4  .

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/opencloud-eu/ios/issues/27

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When managing custom roles through LLDAP and Authelia, OpenCloud does not work correctly due to fixed OIDC scopes, see discussion linked in related issue https://github.com/opencloud-eu/ios/issues/27 like [this](https://github.com/orgs/opencloud-eu/discussions/587), [this](https://github.com/orgs/opencloud-eu/discussions/1640) or [this](https://github.com/orgs/opencloud-eu/discussions/854) or [this discussion I made](https://github.com/orgs/opencloud-eu/discussions/1640)  .

A solution could be to add a custom scopes field into iOS app, and accept it server-side as same as it was done for `WEB_OIDC_SCOPE` (server side part is still missing, see error below).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.

Actually the code ends with error due to server side that does not accept extra scopes: 

```
2025-12-26 16:49:54.318000+0100 OpenCloud[8307.114983] ⚪️ | [AUTH, Openid-Connect] Auth session returned with callbackURL=oc://ios.opencloud.eu?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed.+The+OAuth+2.0+Client+is+not+allowed+to+request+scope+%27banana%27.&iss=https%3A%2F%2F<authelia-path>&state=401D8657-0D20-438C-9DB2-A01C7A027E77, error=(null) [OCAuthenticationMethodOAuth2.m:451|FULL]
```


## Screenshots (if appropriate):
<img width="524" height="1040" alt="Screenshot 2025-12-26 alle 16 56 30" src="https://github.com/user-attachments/assets/b538f83e-d977-4f45-ba18-1a770efa0909" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**docs repository**](https://github.com/opencloud-eu/docs/issues).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have set a pull request label and a meaningful title for changelog automation
- [x] related PR into ios-sdk https://github.com/opencloud-eu/ios-sdk/pull/4 