### PR TITLE
Add custom HTTP header support for proxies

### DIFF
--- a/OpenCloud/Settings/SettingsViewController.swift
+++ b/OpenCloud/Settings/SettingsViewController.swift
@@ -47,6 +47,19 @@ class SettingsViewController: StaticTableViewController {
 			self.addSection(UserInterfaceSettingsSection(userDefaults: userDefaults))
 			self.addSection(DataSettingsSection(userDefaults: userDefaults))
 			self.addSection(DisplaySettingsSection(userDefaults: userDefaults))
+			let headerNameRow = StaticTableViewRow(textFieldWithAction: { (_, sender, action) in
+				if let textField = sender as? UITextField, action == .changed {
+					UserDefaults.standard.set(textField.text, forKey: "custom-http-header-name")
+				}
+			}, placeholder: OCLocalizedString("Header name", nil), value: UserDefaults.standard.string(forKey: "custom-http-header-name") ?? "", autocorrectionType: .no, identifier: "custom-http-header-name")
+
+			let headerValueRow = StaticTableViewRow(textFieldWithAction: { (_, sender, action) in
+				if let textField = sender as? UITextField, action == .changed {
+					UserDefaults.standard.set(textField.text, forKey: "custom-http-header-value")
+				}
+			}, placeholder: OCLocalizedString("Header value", nil), value: UserDefaults.standard.string(forKey: "custom-http-header-value") ?? "", autocorrectionType: .no, identifier: "custom-http-header-value")
+
+			self.addSection(StaticTableViewSection(headerTitle: OCLocalizedString("Custom HTTP Header", nil), footerTitle: OCLocalizedString("Add a custom HTTP header to all requests.", nil), identifier: "section-custom-http-header", rows: [headerNameRow, headerValueRow]))
 			self.addSection(MediaFilesSettingsSection(userDefaults: userDefaults))
 
 			#if !DISABLE_APPSTORE_LICENSING


### PR DESCRIPTION

## Description
Adds a "Custom HTTP Header" settings section in the Settings page with two text fields for a header name and value. Values are saved to UserDefaults.standard and read by the SDK's prepareRequestForScheduling: to attach the header to every outgoing request.

Companion PR: https://github.com/opencloud-eu/ios-sdk/pull/6

## Related Issue
Resolves https://github.com/orgs/opencloud-eu/discussions/2557

## Motivation and Context
Users running OpenCloud behind reverse proxies sometimes need a custom HTTP header on all requests for routing or authentication gating. The iOS app currently has no way to attach custom headers, which can prevent the app from working in these deployments.

## How Has This Been Tested?
Built and tested on iOS sim. Verified via Traefik access logs that the custom header appears on all outgoing requests. Verified that leaving the fields empty results in no change to existing behavior.

## Screenshots (if appropriate):
<img width="368" height="261" alt="image" src="https://github.com/user-attachments/assets/780069e5-a0fa-42b6-abf3-30b947c28897" />

<img width="368" height="252" alt="image" src="https://github.com/user-attachments/assets/50c73787-36cd-46fa-b9a5-123f49faa326" />

<img width="249" height="85" alt="image" src="https://github.com/user-attachments/assets/f4048714-625f-4a37-9217-d899f39ce490" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Added an issue with details about all relevant changes in the [**docs repository**](https://github.com/opencloud-eu/docs/issues).
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have set a pull request label and a meaningful title for changelog automation
